### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#SphereMenu
+# SphereMenu
 
 SphereMenu is a fun menu powered by `UIDynamicAnimator`. Inspired by [Sphere](https://itunes.apple.com/hk/app/sphere-360o-photography/id335671384?mt=8).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
